### PR TITLE
Fix export typo for isHsl

### DIFF
--- a/src/mod.ts
+++ b/src/mod.ts
@@ -55,7 +55,7 @@ export * from './libs/isHexColor.ts';
 // @ts-ignore allowing typedoc to build
 export * from './libs/isHexadecimal.ts';
 // @ts-ignore allowing typedoc to build
-export * from './libs/isHSL.ts';
+export * from './libs/isHsl.ts';
 // @ts-ignore allowing typedoc to build
 export * from './libs/isIBAN.ts';
 // @ts-ignore allowing typedoc to build


### PR DESCRIPTION
Description
----
Export statement and file name don't match causing a failed import

```
app_1       | error: Import 'https://deno.land/x/validate@v0.4.0/src/libs/isHSL.ts' failed, not found.
app_1       |     at https://deno.land/x/validate@v0.4.0/src/mod.ts:58:15
```